### PR TITLE
Feat/gh 14/already admin hyperlink

### DIFF
--- a/lib/presentation/auth/create_credentials.dart
+++ b/lib/presentation/auth/create_credentials.dart
@@ -160,7 +160,7 @@ class _CreateCredentialsPageState extends State<CreateCredentialsPage> {
                                 ),
                                 const SizedBox(height: 30),
                                 CollActionButton(
-                                  text: "Sign in",
+                                  text: "Become an admin!",
                                   loading: _isItLoading(state),
                                   onPressed: () {
                                     setState(() {
@@ -195,24 +195,18 @@ class _CreateCredentialsPageState extends State<CreateCredentialsPage> {
                                   child: RichText(
                                     textAlign: TextAlign.center,
                                     text: TextSpan(
-                                      text: "Already an admin? ",
-                                      style: CollactionTextStyles.body,
-                                      children: <TextSpan>[
-                                        TextSpan(
-                                          text: "Go to Login",
-                                          style: CollactionTextStyles.bodyBold,
-                                          recognizer: TapGestureRecognizer()
-                                            ..onTap = () async {
-                                              BlocProvider.of<NavigationBloc>(
-                                                      context)
-                                                  .add(
-                                                NavigateToPageEvent(
-                                                  route: '/log-in',
-                                                ),
-                                              );
-                                            },
-                                        ),
-                                      ],
+                                      text: "Go to Login",
+                                      style: CollactionTextStyles.bodyBold,
+                                      recognizer: TapGestureRecognizer()
+                                        ..onTap = () async {
+                                          BlocProvider.of<NavigationBloc>(
+                                                  context)
+                                              .add(
+                                            NavigateToPageEvent(
+                                              route: '/log-in',
+                                            ),
+                                          );
+                                        },
                                     ),
                                   ),
                                 )

--- a/lib/presentation/auth/link_auth_page.dart
+++ b/lib/presentation/auth/link_auth_page.dart
@@ -93,7 +93,7 @@ class _LinkAuthPageState extends State<LinkAuthPage> {
                             style: CollactionTextStyles.captionStyle,
                             children: <TextSpan>[
                               TextSpan(
-                                  text: "collaction@org ",
+                                  text: "@collaction.org ",
                                   style: CollactionTextStyles.captionStyleBold),
                               TextSpan(
                                   text:


### PR DESCRIPTION
Used a TapGestureRecognizer to listen for tap events on the "Go to Login" text, and redirect to the log-in screen using the NavigationBloc.

I've tested in link_auth_page and it works, but wasn't able to test it in create_credentials, since it currently isn't accessible.