### PR TITLE
fix: bad version causing workflows to fail

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
         with:
-          channel: 'stable'
+          flutter-version: '3.7.1'
       - run: flutter pub get
       - run: echo ${{secrets.ENV}} | base64 --decode > env
       - run: flutter pub run build_runner build --delete-conflicting-outputs

--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
         with:
+          channel: 'stable'
           flutter-version: '3.7.1'
       - run: flutter pub get
       - run: echo ${{secrets.ENV}} | base64 --decode > env

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -11,6 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
         with:
+          channel: 'stable'
           flutter-version: '3.7.1'
       - run: flutter pub get
       - run: echo ${{secrets.ENV}} | base64 --decode > env

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
         with:
-          channel: 'stable'
+          flutter-version: '3.7.1'
       - run: flutter pub get
       - run: echo ${{secrets.ENV}} | base64 --decode > env
       - run: flutter pub run build_runner build --delete-conflicting-outputs


### PR DESCRIPTION
Previously, the workflows would grab the newest version of flutter and build with that. At some point, an update caused all our workflows to fail. This PR fixes the version to 3.7.1, matching the app.